### PR TITLE
workaround to get  it compiled on OpenSuse 12.3

### DIFF
--- a/third_party/ijar/classfile.cc
+++ b/third_party/ijar/classfile.cc
@@ -27,6 +27,7 @@
 // http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4
 
 #define __STDC_LIMIT_MACROS 1
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h> // for PRIx32
 #include <stddef.h>
 #include <stdio.h>


### PR DESCRIPTION
compilation would fail on OpenSuse 12.3 with either g++ 4.7 or 4.8 
 g++ -I src/main/cpp/ -std=c++0x -c '-DBLAZE_JAVA_CPU="k8"' -DBLAZE_OPENSOURCE=1 -o output/ijar/classfile.cc.o third_party/ijar/classfile.cc
third_party/ijar/classfile.cc: In function ‘devtools_ijar::ClassFile\* devtools_ijar::ReadClass(const void*, size_t)’:
third_party/ijar/classfile.cc:1393:35: error: expected ‘)’ before ‘PRIx32’

I haven't done any C/C++ programming in a while, so forgive my ignorance if this is not a correct fix.
